### PR TITLE
Break unittest2 dependency for Python 2.7

### DIFF
--- a/CHANGES.txt
+++ b/CHANGES.txt
@@ -4,6 +4,8 @@ Changelog
 2.2 - unreleased
 ----------------
 
+- Break dependency on ``unittest2`` for Python 2.7. [icemac]
+
 
 2.1 - 2013-02-10
 ----------------

--- a/README.rst
+++ b/README.rst
@@ -26,3 +26,4 @@ Contributors
 * Hanno Schlichting
 * Christian Heimes
 * Andrei Polushin
+* Michael Howitz

--- a/pythongettext/tests/test_compile.py
+++ b/pythongettext/tests/test_compile.py
@@ -4,6 +4,10 @@ import sys
 
 from pythongettext.msgfmt import Msgfmt
 from pythongettext.msgfmt import PoSyntaxError
+try:
+    import unittest2 as unittest
+except ImportError:  # Python 2.7 or newer
+    import unittest
 
 FOLDER = os.path.dirname(__file__)
 
@@ -14,16 +18,12 @@ if PY3:
 
     def u(s, enc=None):
         return s
-
-    import unittest
 else:
     def b(s):
         return s
 
     def u(s, enc="unicode_escape"):
         return unicode(s, enc)
-
-    import unittest2 as unittest
 
 
 class TestWriter(unittest.TestCase):

--- a/setup.py
+++ b/setup.py
@@ -4,9 +4,8 @@ from setuptools import setup
 
 version = '2.2dev'
 
-PY3 = sys.version_info[0] == 3
 install_requires = []
-if not PY3:
+if sys.version_info < (2, 7):
     install_requires = ['unittest2']
 
 here = os.path.abspath(os.path.dirname(__file__))

--- a/tox.ini
+++ b/tox.ini
@@ -2,11 +2,8 @@
 envlist = py26,py27,py32,py33,pypy
 
 [testenv]
-deps=unittest2
+deps=
 commands=python setup.py test -q
 
-[testenv:py32]
-deps=
-
-[testenv:py33]
-deps=
+[testenv:py26]
+deps=unittest2


### PR DESCRIPTION
Python 2.7 includes the necessary parts of unittest2 so there is no
need to depend on it.